### PR TITLE
fix(cli): lazy-load ScoreVision help paths

### DIFF
--- a/scorevision/__init__.py
+++ b/scorevision/__init__.py
@@ -1,19 +1,103 @@
 import asyncio
 from asyncio import run
+from dataclasses import dataclass
+from importlib import import_module
 from logging import getLogger
 from pathlib import Path
+
 import click
-from scorevision.cli.audit_validator import audit_validator
-from scorevision.cli.central_validator import central_validator
-from scorevision.cli.elements import elements_cli
-from scorevision.cli.manifest import manifest_cli
+
 from scorevision.utils.logging import setup_logging
 from scorevision.utils.settings import get_settings
 
 logger = getLogger(__name__)
 
 
-@click.group(name="sv")
+@dataclass(frozen=True)
+class LazyCommandSpec:
+    module_path: str
+    attribute: str
+    short_help: str
+
+
+LAZY_COMMANDS = {
+    "central-validator": LazyCommandSpec(
+        module_path="scorevision.cli.central_validator",
+        attribute="central_validator",
+        short_help="Run central validator commands.",
+    ),
+    "audit-validator": LazyCommandSpec(
+        module_path="scorevision.cli.audit_validator",
+        attribute="audit_validator",
+        short_help="Run audit validator commands.",
+    ),
+    "manifest": LazyCommandSpec(
+        module_path="scorevision.cli.manifest",
+        attribute="manifest_cli",
+        short_help="Manage manifests.",
+    ),
+    "elements": LazyCommandSpec(
+        module_path="scorevision.cli.elements",
+        attribute="elements_cli",
+        short_help="Inspect registered elements.",
+    ),
+}
+
+ROOT_COMMAND_ORDER = [
+    "runner",
+    "push",
+    "signer",
+    "validate",
+    "central-validator",
+    "audit-validator",
+    "manifest",
+    "elements",
+]
+
+
+def _load_click_command(spec: LazyCommandSpec) -> click.Command:
+    return getattr(import_module(spec.module_path), spec.attribute)
+
+
+class LazyRootGroup(click.Group):
+    """Root Click group that avoids importing every command module for `sv --help`."""
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        available = set(self.commands) | set(LAZY_COMMANDS)
+        return [name for name in ROOT_COMMAND_ORDER if name in available]
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        command = super().get_command(ctx, cmd_name)
+        if command is not None:
+            return command
+
+        spec = LAZY_COMMANDS.get(cmd_name)
+        if spec is None:
+            return None
+
+        return _load_click_command(spec)
+
+    def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        rows: list[tuple[str, str]] = []
+        for subcommand in self.list_commands(ctx):
+            if subcommand in self.commands:
+                cmd = self.commands[subcommand]
+                help_text = cmd.get_short_help_str(formatter.width)
+            else:
+                help_text = LAZY_COMMANDS[subcommand].short_help
+            rows.append((subcommand, help_text))
+
+        if rows:
+            with formatter.section("Commands"):
+                formatter.write_dl(rows)
+
+
+@click.group(
+    name="sv",
+    cls=LazyRootGroup,
+    context_settings={"help_option_names": ["-h", "--help"]},
+    help="ScoreVision CLI for validators, manifests, and element tooling.",
+)
 @click.option(
     "-v",
     "--verbosity",
@@ -27,8 +111,10 @@ def app(verbosity: int):
 
 @app.command("runner")
 def runner_cmd():
+    """Run the central runner loop."""
     from scorevision.validator.central import runner_loop
     from scorevision.utils.prometheus import _start_metrics, mark_service_ready
+
     setup_logging()
 
     _start_metrics()
@@ -64,7 +150,9 @@ def push(
     no_commit,
     element_id,
 ):
+    """Upload model artifacts and optionally deploy or commit them."""
     from scorevision.cli.push import push_ml_model
+
     setup_logging()
 
     try:
@@ -83,7 +171,9 @@ def push(
 
 @app.command("signer")
 def signer_cmd():
+    """Run the signer service."""
     from scorevision.validator.core import run_signer
+
     setup_logging()
 
     asyncio.run(run_signer())
@@ -103,8 +193,10 @@ def signer_cmd():
     "--manifest-path", type=click.Path(exists=True, dir_okay=False), default=None
 )
 def validate_cmd(tail: int, m_min: int, tempo: int, manifest_path):
+    """Run the validator weights loop."""
     from scorevision.validator.core import weights_loop
     from scorevision.utils.prometheus import _start_metrics, mark_service_ready
+
     setup_logging()
 
     _start_metrics()
@@ -119,9 +211,3 @@ def validate_cmd(tail: int, m_min: int, tempo: int, manifest_path):
             commit_on_start=False,
         )
     )
-
-
-app.add_command(audit_validator)
-app.add_command(central_validator)
-app.add_command(manifest_cli)
-app.add_command(elements_cli)

--- a/scorevision/cli/elements.py
+++ b/scorevision/cli/elements.py
@@ -1,17 +1,18 @@
 import click
 from json import dumps
 
-from scorevision.utils.pillar_metric_registry import (
-    element_pillar_registry_availability,
-)
-
 
 @click.group(name="elements")
 def elements_cli():
+    """Inspect supported ScoreVision elements."""
     pass
 
 
 @elements_cli.command("list")
 def list_available_elements():
-    """Create a new manifest from a template."""
+    """List supported elements and their registered pillar coverage."""
+    from scorevision.utils.pillar_metric_registry import (
+        element_pillar_registry_availability,
+    )
+
     click.secho(dumps(element_pillar_registry_availability(), indent=2), fg="green")

--- a/scorevision/cli/manifest.py
+++ b/scorevision/cli/manifest.py
@@ -3,22 +3,9 @@ import asyncio
 from json import loads
 from pathlib import Path
 from base64 import b64decode
-from datetime import datetime, timezone
 from hashlib import sha256
 
 import click
-from nacl.signing import SigningKey
-
-from scorevision.utils.manifest import Manifest
-from scorevision.utils.settings import get_settings
-from scorevision.utils.manifest import yaml
-from scorevision.utils.r2 import (
-    r2_get_object,
-    r2_put_json,
-    r2_put_bytes,
-    r2_delete_object,
-)
-from scorevision.utils.bittensor_helpers import get_subtensor
 
 # ============================================================
 # TEMPLATES
@@ -32,6 +19,42 @@ TEMPLATES = {
         "elements": [],
     }
 }
+
+
+def get_settings():
+    from scorevision.utils.settings import get_settings as _get_settings
+
+    return _get_settings()
+
+
+def r2_get_object(*args, **kwargs):
+    from scorevision.utils.r2 import r2_get_object as _r2_get_object
+
+    return _r2_get_object(*args, **kwargs)
+
+
+def r2_put_json(*args, **kwargs):
+    from scorevision.utils.r2 import r2_put_json as _r2_put_json
+
+    return _r2_put_json(*args, **kwargs)
+
+
+def r2_put_bytes(*args, **kwargs):
+    from scorevision.utils.r2 import r2_put_bytes as _r2_put_bytes
+
+    return _r2_put_bytes(*args, **kwargs)
+
+
+def r2_delete_object(*args, **kwargs):
+    from scorevision.utils.r2 import r2_delete_object as _r2_delete_object
+
+    return _r2_delete_object(*args, **kwargs)
+
+
+async def get_subtensor():
+    from scorevision.utils.bittensor_helpers import get_subtensor as _get_subtensor
+
+    return await _get_subtensor()
 
 
 # ============================================================
@@ -66,6 +89,9 @@ def create_manifest_cmd(
     template: str, window_id: str, expiry_block: int, output: Path, tee_key: Path | None
 ):
     """Create a new manifest from a template."""
+    from nacl.signing import SigningKey
+    from scorevision.utils.manifest import yaml
+
     if template not in TEMPLATES:
         raise click.ClickException(f"Unknown template: {template}")
 
@@ -103,6 +129,8 @@ def create_manifest_cmd(
 )
 def validate_manifest_cmd(manifest_path: Path, public_key: str | None):
     """Validate manifest schema and optionally its Ed25519 signature."""
+    from scorevision.utils.manifest import Manifest
+
     try:
         # Load the manifest
         manifest = Manifest.load_yaml(manifest_path)
@@ -176,6 +204,9 @@ def publish_manifest_cdn_cmd(
     """
     Sign, upload (with retries), integrity-check, and update index.json.
     """
+    from nacl.signing import SigningKey
+
+    from scorevision.utils.manifest import Manifest
 
     settings = get_settings()
     bucket = settings.R2_BUCKET

--- a/tests/cli/test_root_help.py
+++ b/tests/cli/test_root_help.py
@@ -1,0 +1,50 @@
+from click.testing import CliRunner
+
+import scorevision
+
+
+def test_root_help_lists_scorevision_commands_without_loading_lazy_groups(monkeypatch) -> None:
+    """`sv --help` should work without importing lazy subcommand modules."""
+
+    def fail_on_lazy_load(spec):
+        raise AssertionError(f"unexpected lazy import for {spec.module_path}")
+
+    monkeypatch.setattr(scorevision, "_load_click_command", fail_on_lazy_load)
+
+    result = CliRunner().invoke(scorevision.app, ["--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "ScoreVision CLI" in result.output
+    assert "-v, --verbosity" in result.output
+    for command in [
+        "runner",
+        "push",
+        "signer",
+        "validate",
+        "central-validator",
+        "audit-validator",
+        "manifest",
+        "elements",
+    ]:
+        assert command in result.output
+
+
+def test_manifest_help_loads_lazily_from_root() -> None:
+    """`sv manifest --help` should load the manifest group only when requested."""
+
+    result = CliRunner().invoke(scorevision.app, ["manifest", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "Manage ScoreVision manifests." in result.output
+    for command in ["create", "validate", "publish", "list", "current"]:
+        assert command in result.output
+
+
+def test_elements_help_loads_lazily_from_root() -> None:
+    """`sv elements --help` should render without loading unrelated command modules."""
+
+    result = CliRunner().invoke(scorevision.app, ["elements", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "elements" in result.output
+    assert "list" in result.output


### PR DESCRIPTION
Closes #45

## Summary
- lazy-load root CLI command groups so root help renders ScoreVision-specific commands without importing every subcommand module
- defer heavy manifest and elements imports until command execution so grouped help paths stay lightweight
- add regression tests covering root help and lazy grouped help from the root CLI

## Validation
- uv run sv --help
- uv run sv manifest --help
- uv run sv elements --help
- uv run pytest tests/cli/test_root_help.py tests/cli/test_manifest_create.py tests/cli/test_manifest_validate.py tests/cli/test_manifest_list.py -q

## Notes
- this keeps the existing sv entrypoint and command names intact while making help rendering resilient in a fresh source environment
